### PR TITLE
Prevent missing case pattern with never typing

### DIFF
--- a/src/atoms/Emoji.tsx
+++ b/src/atoms/Emoji.tsx
@@ -36,7 +36,8 @@ const emojiByName = (name: EmojiName): string => {
     case EmojiName.CrossMark:
       return "❌";
     default:
-      return "";
+      const _: never = name;
+      return _;
   }
 };
 

--- a/src/pages/AppContainer.tsx
+++ b/src/pages/AppContainer.tsx
@@ -55,9 +55,12 @@ const AppContainer: React.FunctionComponent = () => {
           case "denied":
             alert("You rejected the notification :(　Please accept it.");
             break;
-          default:
+          case "default":
             alert("Can not judge to use notification :(　Please accept it.");
             break;
+          default:
+            const _: never = result;
+            return _;
         }
       });
     }


### PR DESCRIPTION
I personally prefer this style. TypeScript never in case prevents missing implementation for enums.