### PR TITLE
Avoid to use TypeScript enum

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,6 +25,13 @@
         "singleReturnOnly": false,
         "classPropertiesAllowed": false
       }
+    ],
+    "no-restricted-syntax": [
+      "error",
+      {
+        "selector": "TSEnumDeclaration",
+        "message": "Don't declare enums. ref: https://www.kabuku.co.jp/developers/good-bye-typescript-enum"
+      }
     ]
   }
 }

--- a/src/atoms/Emoji.tsx
+++ b/src/atoms/Emoji.tsx
@@ -15,13 +15,15 @@ const Emoji: React.FunctionComponent<{
   );
 };
 
-export enum EmojiName {
-  Car,
-  Speaker,
-  Wastebasket,
-  Plus,
-  CrossMark,
-}
+export const EmojiName = {
+  Car: "Car",
+  Speaker: "Speaker",
+  Wastebasket: "Wastebasket",
+  Plus: "Plus",
+  CrossMark: "CrossMark",
+} as const;
+
+export type EmojiName = typeof EmojiName[keyof typeof EmojiName];
 
 const emojiByName = (name: EmojiName): string => {
   switch (name) {


### PR DESCRIPTION
I agreed https://www.kabuku.co.jp/developers/good-bye-typescript-enum.
So avoiding enum and using const will be better, I think.