### PR TITLE
Validate to input interval is positive number

### DIFF
--- a/src/pages/AppContainer.tsx
+++ b/src/pages/AppContainer.tsx
@@ -115,9 +115,11 @@ const AppContainer: React.FunctionComponent = () => {
   const onIntervalChange = React.useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       const newIntervalMinutes = parseInt(event.currentTarget.value);
-      const newIntervalSeconds = newIntervalMinutes * 60;
-      setIntervalSeconds(newIntervalSeconds);
-      intervalSecondsRef.current = newIntervalSeconds;
+      if (newIntervalMinutes > 0) {
+        const newIntervalSeconds = newIntervalMinutes * 60;
+        setIntervalSeconds(newIntervalSeconds);
+        intervalSecondsRef.current = newIntervalSeconds;
+      }
     },
     []
   );


### PR DESCRIPTION
Currently validating the interval minutes with the input field `min` restriction.
It basically works in the ⬆️ and ⬇️ .
But directly inputting `0`, or copy and paste `-7` will be accepts by mobu. 

<img width="1330" alt="スクリーンショット 2021-04-21 0 35 51" src="https://user-images.githubusercontent.com/1180335/115425741-d88f3980-a23a-11eb-934e-bb30b97ab09b.png">
<img width="580" alt="スクリーンショット 2021-04-21 0 39 29" src="https://user-images.githubusercontent.com/1180335/115425753-daf19380-a23a-11eb-8551-2d63d88e888f.png">

it is user fault. But we should consider to provide enterprise edition of mobu. These loopholes should be prevented 😤 