### PR TITLE
Prevent to show same users with inputting whitespaces

### DIFF
--- a/src/atoms/Text.css
+++ b/src/atoms/Text.css
@@ -1,4 +1,5 @@
 .text {
   font-size: 1.5rem;
   width: 100%;
+  white-space: pre;
 }

--- a/src/pages/AppContainer.tsx
+++ b/src/pages/AppContainer.tsx
@@ -107,7 +107,7 @@ const AppContainer: React.FunctionComponent = () => {
 
   const onUsernameChange = React.useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
-      setUsername(event.currentTarget.value);
+      setUsername(event.currentTarget.value.trim());
     },
     []
   );


### PR DESCRIPTION
`mobu` handles users as just a string. Then the string having whitespaces, they will be handled as another user.
It might be acceptable spec, but currently showing them as same user in view.

Before
---

<img width="772" alt="スクリーンショット 2021-04-21 1 50 26" src="https://user-images.githubusercontent.com/1180335/115434766-05941a00-a244-11eb-9329-d1e3ba2ceb4b.png">
<img width="513" alt="スクリーンショット 2021-04-21 1 50 46" src="https://user-images.githubusercontent.com/1180335/115434770-075ddd80-a244-11eb-9428-252b71cb73ab.png">

It is a CSS issue, this PR fixes it.

After
---

<img width="802" alt="スクリーンショット 2021-04-21 1 53 25" src="https://user-images.githubusercontent.com/1180335/115435036-63286680-a244-11eb-843b-793e2a5f7851.png">

And I can't think of usecases of padding whitespaces for start and end. So this PR trim them.