### PR TITLE
Assign maintainers as reviewer instead of by name

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,6 @@ updates:
     interval: daily
   open-pull-requests-limit: 10
   reviewers:
-  - pankona
-  - kachick
+  - "mobu-of-the-world/maintainers"
   labels:
   - automerge


### PR DESCRIPTION
https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates#reviewers

<img width="959" alt="スクリーンショット 2021-05-08 22 29 19" src="https://user-images.githubusercontent.com/1180335/117541551-5a5ecf80-b04f-11eb-9413-c1ef75d1e94d.png">

Now, we are team!