### PR TITLE
Fix `Manifest: Line: 1, column: 1, Syntax error.` error

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,11 +14,6 @@
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
       Only files inside the `public` folder can be referenced from the HTML.


### PR DESCRIPTION
* Problem
    * `yarn start` opens your browser
    * The browser warns `Manifest: Line: 1, column: 1, Syntax error.`
* Solution
    * Don't require a missing file which is resolved as index.html