### PR TITLE
Trivial bugfix: don't prohibit username with spaces

### DIFF
--- a/src/pages/AppContainer.tsx
+++ b/src/pages/AppContainer.tsx
@@ -34,7 +34,7 @@ const AppContainer: React.FunctionComponent = () => {
     getCookieSoundEnabled()
   );
 
-  const registerDisabled = () =>
+  const registerDisabled = (username: string) =>
     username === emptyUsername ||
     blankStringsPattern.test(username) ||
     users.includes(username);
@@ -186,7 +186,7 @@ const AppContainer: React.FunctionComponent = () => {
       username={username}
       users={users}
       intervalMinutes={Math.ceil(intervalSeconds / 60)}
-      registerDisabled={registerDisabled()}
+      registerDisabled={registerDisabled(username.trim())}
       showMenu={showMenu}
       soundConfigProps={soundConfigProps}
     ></AppComponent>

--- a/src/pages/AppContainer.tsx
+++ b/src/pages/AppContainer.tsx
@@ -107,7 +107,7 @@ const AppContainer: React.FunctionComponent = () => {
 
   const onUsernameChange = React.useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
-      setUsername(event.currentTarget.value.trim());
+      setUsername(event.currentTarget.value);
     },
     []
   );

--- a/src/pages/AppContainer.tsx
+++ b/src/pages/AppContainer.tsx
@@ -128,7 +128,7 @@ const AppContainer: React.FunctionComponent = () => {
     (event: React.FormEvent<HTMLFormElement>) => {
       event.preventDefault();
       setUsers((prev) => {
-        const newUsers = [...prev, username];
+        const newUsers = [...prev, username.trim()];
         setCookieUsers(newUsers);
         return newUsers;
       });


### PR DESCRIPTION
* Problem: You can't input username with space like "7 days to die" or "Vim script"
    * It transforms into "7daystodie" or "Vimscript", which do not make sense
* Solution: Don't remove spaces yours input