### PR TITLE
Don't open browser tab every time when you restart

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "typescript": "^4.2.4"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "env BROWSER=none react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "test:ci": "CI=true react-scripts test --passWithNoTests",


### PR DESCRIPTION
* Problem: `yarn start` creats new browsr tab to open http://localhost:3000/
  no matter how many tabs you have opened that page
* Solution: Don't add automatically but just show a message to open the URL.