### PR TITLE
[Suggestion]Disable interval after the timer is started

### DIFF
--- a/src/atoms/TextInput.css
+++ b/src/atoms/TextInput.css
@@ -3,3 +3,6 @@
   width: 100%;
   border-bottom: 1px solid;
 }
+.textinput:disabled {
+  color: #aaa;
+}

--- a/src/molecules/Interval.tsx
+++ b/src/molecules/Interval.tsx
@@ -7,7 +7,8 @@ import "./Interval.css";
 const Interval: React.FunctionComponent<{
   onIntervalChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   intervalMinutes: number;
-}> = ({ onIntervalChange, intervalMinutes }) => {
+  disabled: boolean;
+}> = ({ onIntervalChange, intervalMinutes, disabled }) => {
   return (
     <div className="interval">
       <div className="interval--text">Interval (minutes)&nbsp;:&nbsp;</div>
@@ -16,6 +17,7 @@ const Interval: React.FunctionComponent<{
         type="number"
         value={intervalMinutes}
         min={1}
+        disabled={disabled}
       />
     </div>
   );

--- a/src/organisms/Session.tsx
+++ b/src/organisms/Session.tsx
@@ -19,6 +19,7 @@ const Session: React.FunctionComponent<{
       <Interval
         onIntervalChange={onIntervalChange}
         intervalMinutes={intervalMinutes}
+        disabled={timerProps.iterationCount > 0}
       />
       <SoundConfig {...soundConfigProps} />
     </div>

--- a/src/pages/AppContainer.tsx
+++ b/src/pages/AppContainer.tsx
@@ -128,7 +128,7 @@ const AppContainer: React.FunctionComponent = () => {
         intervalSecondsRef.current = newIntervalSeconds;
       }
     },
-    [intervalSeconds]
+    []
   );
 
   const onUserRegister = React.useCallback(

--- a/src/pages/AppContainer.tsx
+++ b/src/pages/AppContainer.tsx
@@ -28,7 +28,7 @@ const AppContainer: React.FunctionComponent = () => {
   );
 
   const [tickCount, setTickCount] = React.useState(0);
-  const [iterationCount, setIterationCount] = React.useState(1);
+  const [iterationCount, setIterationCount] = React.useState(0);
   const [showMenu, setShowMenu] = React.useState(false);
   const [soundEnabled, setSoundEnabled] = React.useState(
     getCookieSoundEnabled()
@@ -40,6 +40,9 @@ const AppContainer: React.FunctionComponent = () => {
     users.includes(username);
 
   const onStartOrPause = React.useCallback(() => {
+    if (iterationCount === 0) {
+      setIterationCount(1);
+    }
     if (timerID.current) {
       clearInterval(timerID.current);
       timerID.current = undefined;
@@ -89,12 +92,16 @@ const AppContainer: React.FunctionComponent = () => {
         }
       }
     }, 1000);
-  }, [count, timerID, soundEnabled]);
+  }, [count, timerID, soundEnabled, iterationCount]);
 
   const onReset = React.useCallback(() => {
+    if (timerID.current) {
+      clearInterval(timerID.current);
+      timerID.current = undefined;
+    }
     count.current = 0;
     setTickCount(count.current);
-    setIterationCount(1);
+    setIterationCount(0);
   }, [count]);
 
   const onShuffle = React.useCallback(() => {

--- a/src/pages/AppContainer.tsx
+++ b/src/pages/AppContainer.tsx
@@ -121,7 +121,7 @@ const AppContainer: React.FunctionComponent = () => {
         intervalSecondsRef.current = newIntervalSeconds;
       }
     },
-    []
+    [intervalSeconds]
   );
 
   const onUserRegister = React.useCallback(


### PR DESCRIPTION
### Aiming & What I did

* Current `Interval` form has a bug. ~So I wanted to fix it.~
    * ~`onIntervalChange` in `React.useCallback` has a dependency with `intervalSeconds`, but it doesn't pass to the method as second argument.~
    * It causes that a user can't change the interval minute even if he/she changes the form.
    * You can confirm the bug below. 
![mobu_bug](https://user-images.githubusercontent.com/1495423/117840590-45847500-b2b7-11eb-95cf-4a1a44d8b25d.gif)
* OK, the above bug should be fixed. But... really should we enable to change the interval after starting the timer? I thought 'No'.
    * If the timer is 1:59 and a user change the form to 2 minutes from 1 minute, the time never stop. It matters.
    * So I disabled the form after the timer is stared.
* How can I disable the form?
    * I felt that using the `IterationCount` is natural. when a user in an iteration, he/she can't change the interval.
    * Therefore I changed the interval starts with 0. I know it's controversial change. So I'm happy to ask the maintainers' thought, @kachick and @pankona.

### Image
![mobu_disable_interval](https://user-images.githubusercontent.com/1495423/117836383-98f4c400-b2b3-11eb-9fc9-29d7ad1c6c05.gif)

* The interval form is disabled after timer is started.
* The Iteration count starts with 0.
* When the reset button is clicked, the timer is stopped and the iteration count inits with 0. Of course the interval form is enabled again.