### PR TITLE
Use padding in atom components instead of margin

### DIFF
--- a/src/atoms/Emoji.css
+++ b/src/atoms/Emoji.css
@@ -1,7 +1,6 @@
 .emoji {
   font-size: 1.5rem;
-  margin-left: 0.5rem;
-  margin-right: 0.5rem;
+  padding: 0 0.5rem;
 }
 
 .emoji--clickable {


### PR DESCRIPTION
Components should not have styles that define how the component be displayed in parent components, like margin.

Referable article: https://zenn.dev/seya/articles/09545c7503baa4