### PR TITLE
Move packages in devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "react-dom": "^17.0.2",
     "react-scripts": "^4.0.1",
     "ress": "^4.0.0",
-    "typescript": "^4.3.2"
+    "typescript": "^4.3.2",
+    "eslint-plugin-prefer-arrow": "^1.2.3",
+    "prettier": "^2.3.0"
   },
   "scripts": {
     "start": "env BROWSER=none react-scripts start",
@@ -44,9 +46,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "devDependencies": {
-    "eslint-plugin-prefer-arrow": "^1.2.3",
-    "prettier": "^2.3.0"
   }
 }


### PR DESCRIPTION
Hello 👋 

This is a cosmetic change though, I moved the packages in `devDependencies` to `dependencies` because it's not necessary to categorize for an application that is built on create-react-app. It's okay to have all packages under `dependencies`.

**Refs**
- https://github.com/facebook/create-react-app/issues/2696
- https://stackoverflow.com/questions/44868453/create-react-app-install-devdepencies-in-dependencies-section
- https://scrapbox.io/ohbarye/Dependencies_in_Create_React_App