### PR TITLE
Move packages for development to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,14 @@
   "private": true,
   "homepage": "./",
   "dependencies": {
+    "js-cookie": "^2.2.1",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
+    "react-scripts": "^4.0.1",
+    "ress": "^4.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^4.3.2",
     "@testing-library/jest-dom": "^5.13.0",
     "@testing-library/react": "^11.2.7",
     "@testing-library/user-event": "^13.1.9",
@@ -12,12 +20,6 @@
     "@types/node": "^15.12.2",
     "@types/react": "^17.0.9",
     "@types/react-dom": "^17.0.6",
-    "js-cookie": "^2.2.1",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "react-scripts": "^4.0.1",
-    "ress": "^4.0.0",
-    "typescript": "^4.3.2",
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "prettier": "^2.3.1"
   },


### PR DESCRIPTION
I found some packages that are used only in build time specified as 'dependencies' in package.json. This PR moves them to 'devDependencies'.