### PR TITLE
Track github-actions updates by dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,11 @@
 version: 2
 updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "daily"
+  reviewers:
+    - "mobu-of-the-world/maintainers"
 - package-ecosystem: npm
   directory: "/"
   schedule:


### PR DESCRIPTION
dependabot can track GitHub Actions updates.
The example is https://github.com/test-unit/test-unit/pull/188 => https://github.com/test-unit/test-unit/pull/215

We could got actions/checkout updates if introduced this.