### PR TITLE
Fix around elapsed time formatter

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,11 +4,13 @@
     "plugin:@typescript-eslint/eslint-recommended",
     "plugin:@typescript-eslint/recommended"
   ],
-  "plugins": ["react-hooks", "prefer-arrow"],
+  "plugins": ["deprecation", "react-hooks", "prefer-arrow"],
   "parser": "@typescript-eslint/parser",
   "env": { "browser": true, "node": true, "es6": true },
   "parserOptions": {
-    "sourceType": "module"
+    "ecmaVersion": 2020,
+    "sourceType": "module",
+    "project": "./tsconfig.json"
   },
   "rules": {
     "react-hooks/rules-of-hooks": "error",
@@ -32,6 +34,7 @@
         "selector": "TSEnumDeclaration",
         "message": "Don't declare enums. ref: https://www.kabuku.co.jp/developers/good-bye-typescript-enum"
       }
-    ]
+    ],
+    "deprecation/deprecation": "error"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@typescript-eslint/parser": "^5.27.1",
         "@vitejs/plugin-react": "^1.3.2",
         "eslint": "^8.17.0",
+        "eslint-plugin-deprecation": "^1.3.2",
         "eslint-plugin-prefer-arrow": "^1.2.3",
         "eslint-plugin-react-hooks": "^4.5.0",
         "jest": "^28.1.1",
@@ -1604,6 +1605,25 @@
         }
       }
     },
+    "node_modules/@typescript-eslint/experimental-utils": {
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.27.1.tgz",
+      "integrity": "sha512-Vd8uewIixGP93sEnmTRIH6jHZYRQRkGPDPpapACMvitJKX8335VHNyqKTE+mZ+m3E2c5VznTZfSsSsS5IF7vUA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/utils": "5.27.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/@typescript-eslint/parser": {
       "version": "5.27.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.27.1.tgz",
@@ -2827,6 +2847,27 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/eslint-plugin-deprecation": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-deprecation/-/eslint-plugin-deprecation-1.3.2.tgz",
+      "integrity": "sha512-z93wbx9w7H/E3ogPw6AZMkkNJ6m51fTZRNZPNQqxQLmx+KKt7aLkMU9wN67s71i+VVHN4tLOZ3zT3QLbnlC0Mg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/experimental-utils": "^5.0.0",
+        "tslib": "^2.3.1",
+        "tsutils": "^3.21.0"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "typescript": "^3.7.5 || ^4.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-deprecation/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "dev": true
     },
     "node_modules/eslint-plugin-prefer-arrow": {
       "version": "1.2.3",
@@ -7319,6 +7360,15 @@
         "tsutils": "^3.21.0"
       }
     },
+    "@typescript-eslint/experimental-utils": {
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.27.1.tgz",
+      "integrity": "sha512-Vd8uewIixGP93sEnmTRIH6jHZYRQRkGPDPpapACMvitJKX8335VHNyqKTE+mZ+m3E2c5VznTZfSsSsS5IF7vUA==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/utils": "5.27.1"
+      }
+    },
     "@typescript-eslint/parser": {
       "version": "5.27.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.27.1.tgz",
@@ -8133,6 +8183,25 @@
           "version": "0.20.2",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
           "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-deprecation": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-deprecation/-/eslint-plugin-deprecation-1.3.2.tgz",
+      "integrity": "sha512-z93wbx9w7H/E3ogPw6AZMkkNJ6m51fTZRNZPNQqxQLmx+KKt7aLkMU9wN67s71i+VVHN4tLOZ3zT3QLbnlC0Mg==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/experimental-utils": "^5.0.0",
+        "tslib": "^2.3.1",
+        "tsutils": "^3.21.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@typescript-eslint/parser": "^5.27.1",
     "@vitejs/plugin-react": "^1.3.2",
     "eslint": "^8.17.0",
+    "eslint-plugin-deprecation": "^1.3.2",
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-react-hooks": "^4.5.0",
     "jest": "^28.1.1",

--- a/src/session/Timer.tsx
+++ b/src/session/Timer.tsx
@@ -8,12 +8,7 @@ import { useSetPersistedUsers, useUsers } from "../common/usersContexts";
 import "./Timer.css";
 import "../common/Button.css";
 import audiofile from "./assets/bell.mp3";
-
-const numberToTimeString = (count: number): string => {
-  const elapsedTime = new Date(count);
-  elapsedTime.setSeconds(count);
-  return elapsedTime.toISOString().substr(11, 8);
-};
+import { readableElapsedTime } from "./timeHelpers";
 
 const Timer: React.FC<{
   intervalSecondsRef: React.MutableRefObject<number>;
@@ -105,7 +100,7 @@ const Timer: React.FC<{
 
   return (
     <>
-      <Text>elapsed time: {numberToTimeString(tickCount)}</Text>
+      <Text>elapsed time: {readableElapsedTime(tickCount)}</Text>
       <Text>(iteration: {iterationCount})</Text>
       <div className="timer--divider" />
       <Button

--- a/src/session/timeHelpers.test.ts
+++ b/src/session/timeHelpers.test.ts
@@ -1,0 +1,9 @@
+import { readableElapsedTime } from "./timeHelpers";
+import { expect, test } from "@jest/globals";
+
+test("returns readable format", async () => {
+  expect(readableElapsedTime(42)).toBe("00:00:42");
+  expect(readableElapsedTime(142)).toBe("00:02:22");
+  expect(readableElapsedTime(1001)).toBe("00:16:41");
+  expect(readableElapsedTime(60000)).toBe("16:40:00");
+});

--- a/src/session/timeHelpers.ts
+++ b/src/session/timeHelpers.ts
@@ -1,6 +1,6 @@
 export const readableElapsedTime = (seconds: number): string => {
-  const elapsedTime = new Date(seconds);
-  elapsedTime.setSeconds(seconds);
+  const date = new Date(0);
+  date.setSeconds(seconds);
   // eslint-disable-next-line deprecation/deprecation
-  return elapsedTime.toISOString().substr(11, 8);
+  return date.toISOString().substr(11, 8);
 };

--- a/src/session/timeHelpers.ts
+++ b/src/session/timeHelpers.ts
@@ -1,6 +1,5 @@
 export const readableElapsedTime = (seconds: number): string => {
   const date = new Date(0);
   date.setSeconds(seconds);
-  // eslint-disable-next-line deprecation/deprecation
-  return date.toISOString().substr(11, 8);
+  return date.toISOString().substring(11, 19);
 };

--- a/src/session/timeHelpers.ts
+++ b/src/session/timeHelpers.ts
@@ -1,0 +1,6 @@
+export const readableElapsedTime = (seconds: number): string => {
+  const elapsedTime = new Date(seconds);
+  elapsedTime.setSeconds(seconds);
+  // eslint-disable-next-line deprecation/deprecation
+  return elapsedTime.toISOString().substr(11, 8);
+};

--- a/src/session/timeHelpers.ts
+++ b/src/session/timeHelpers.ts
@@ -1,5 +1,4 @@
 export const readableElapsedTime = (seconds: number): string => {
-  const date = new Date(0);
-  date.setSeconds(seconds);
+  const date = new Date(seconds * 1000);
   return date.toISOString().substring(11, 19);
 };


### PR DESCRIPTION
Current formatting elapsed time has 2 issues.

* Bug: It calls Date constructor with given second as a milliseconds, it makes unexpected time if given seconds is large number.
* Not good: Using String.prototype.substr(), it is a deprecated method.

So this PR does...

* Prevent to use deprecated methods anymore, it checked in eslint plugin
* Add tests
* Fix the formatting method