### PR TITLE
Moderate footer

### DIFF
--- a/src/footer/footer.module.css
+++ b/src/footer/footer.module.css
@@ -1,10 +1,8 @@
 .footer {
   font-size: 0.7rem;
   color: darkgrey;
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
+  position: sticky;
+  top: 100%;
   margin-bottom: 0.3rem;
   text-align: center;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -6,6 +6,10 @@ body {
   height: 100vh;
 }
 
+#root {
+  height: 100%;
+}
+
 @media (prefers-color-scheme: dark) {
   body {
     color: #c9d1d9;


### PR DESCRIPTION
Currently footer always apears itself. It makes annoy especially in mobile view. So this change makes moderate footer, it will only be shown when scrolled.

<img width="323" alt="before" src="https://user-images.githubusercontent.com/1180335/173000711-9698a351-e07e-468b-88dc-9c29d3af2475.png">

⬇️ 

<img width="743" alt="after-0" src="https://user-images.githubusercontent.com/1180335/173000701-4a120189-7d80-4093-8456-7d3738a74ec4.png">
<img width="326" alt="after-1" src="https://user-images.githubusercontent.com/1180335/173000706-c1b0d930-e4ae-48b2-b2f3-85446aa1399b.png">
<img width="280" alt="after-2" src="https://user-images.githubusercontent.com/1180335/173000709-e7bfc5e4-1303-4b10-956e-45c4ece14d8b.png">

