### PR TITLE
Implement unit selector to improve timer development

### DIFF
--- a/src/session/Interval.tsx
+++ b/src/session/Interval.tsx
@@ -1,28 +1,55 @@
-import type { ChangeEvent } from "react";
+import { ChangeEvent, useCallback } from "react";
 
 import TextInput from "../common/TextInput";
 
 import css from "./Interval.module.css";
 
 const Interval = ({
-  onIntervalChange,
-  intervalMinutes,
+  setIntervalSeconds,
+  intervalSeconds,
   disabled,
 }: {
-  onIntervalChange: (event: ChangeEvent<HTMLInputElement>) => void;
-  intervalMinutes: number;
+  setIntervalSeconds: (value: React.SetStateAction<number>) => void;
+  intervalSeconds: number;
   disabled: boolean;
 }) => {
+  const params = new URL(window.location.href).searchParams;
+  const unit = params.get("unit") === "seconds" ? "seconds" : "minutes";
+  const interval = {
+    seconds: intervalSeconds,
+    minutes: Math.ceil(intervalSeconds / 60),
+  }[unit];
+  const onIntervalChange = {
+    seconds: useCallback(
+      (event: ChangeEvent<HTMLInputElement>) => {
+        const newIntervalSeconds = parseInt(event.currentTarget.value);
+        if (newIntervalSeconds > 0) {
+          setIntervalSeconds(newIntervalSeconds);
+        }
+      },
+      [setIntervalSeconds]
+    ),
+    minutes: useCallback(
+      (event: ChangeEvent<HTMLInputElement>) => {
+        const newIntervalMinutes = parseInt(event.currentTarget.value);
+        if (newIntervalMinutes > 0) {
+          const newIntervalSeconds = newIntervalMinutes * 60;
+          setIntervalSeconds(newIntervalSeconds);
+        }
+      },
+      [setIntervalSeconds]
+    ),
+  }[unit];
+
   return (
     <div className={css["interval"]}>
       <div className={css["interval--text"]}>
-        Interval (minutes)&nbsp;:&nbsp;
+        Interval {`(${unit})`}&nbsp;:&nbsp;
       </div>
       <TextInput
         onChange={onIntervalChange}
         type="number"
-        value={intervalMinutes}
-        min={1}
+        value={interval}
         disabled={disabled}
       />
     </div>

--- a/src/session/Session.tsx
+++ b/src/session/Session.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useState } from "react";
 
 import Timer from "./Timer";
 import Interval from "./Interval";
@@ -20,16 +20,6 @@ const Session = () => {
   const [isSoundEnabled, setIsSoundEnabled] = useState(
     getStorageSoundEnabled()
   );
-  const onIntervalChange = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      const newIntervalMinutes = parseInt(event.currentTarget.value);
-      if (newIntervalMinutes > 0) {
-        const newIntervalSeconds = newIntervalMinutes * 60;
-        setIntervalSeconds(newIntervalSeconds);
-      }
-    },
-    []
-  );
 
   return (
     <div className={css["session"]}>
@@ -41,8 +31,8 @@ const Session = () => {
       />
       <div className={css["session--divider"]} />
       <Interval
-        onIntervalChange={onIntervalChange}
-        intervalMinutes={Math.ceil(intervalSeconds / 60)}
+        setIntervalSeconds={setIntervalSeconds}
+        intervalSeconds={intervalSeconds}
         disabled={iterationCount > 0}
       />
       <SoundConfig


### PR DESCRIPTION
I feel annoy when touching around timers. Because the manual test taking many hours caused on min duration is 1 minute.

So this PR provide as a debug mode. We can specify `seconds` with the query params. Without it, keeps current behaviors.
I have implemented the feature in https://github.com/kachick/mobu-elm as a UI. However URL based custom will fit for this mobu. I guess.

<img width="1051" alt="default" src="https://user-images.githubusercontent.com/1180335/176581387-ea5b8c9c-20d3-45c2-be6f-ffa1fb2270d0.png">
<img width="1071" alt="minutes" src="https://user-images.githubusercontent.com/1180335/176581390-3c29bbb9-b478-4b6d-9084-ca6e8abe997f.png">
<img width="1048" alt="seconds" src="https://user-images.githubusercontent.com/1180335/176581392-59e716ed-b0ff-4e3a-bc6c-a37863a4670b.png">

This might help to tackle https://github.com/mobu-of-the-world/mobu/issues/484
