### PR TITLE
Integrate dprint to enable `no-mixed-operators` in eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,6 +16,7 @@
     }
   },
   "rules": {
+    "no-mixed-operators": "error",
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
     "no-unused-vars": "off",

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,22 +1,22 @@
 version: 2
 updates:
-- package-ecosystem: "github-actions"
-  directory: "/"
-  schedule:
-    interval: "daily"
-  reviewers:
-    - "mobu-of-the-world/maintainers"
-  labels:
-    - automerge
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  reviewers:
-    - "mobu-of-the-world/maintainers"
-  labels:
-    - automerge
-  ignore:
-    - dependency-name: "@types/*"
-      update-types: ["version-update:semver-major"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "mobu-of-the-world/maintainers"
+    labels:
+      - automerge
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    reviewers:
+      - "mobu-of-the-world/maintainers"
+    labels:
+      - automerge
+    ignore:
+      - dependency-name: "@types/*"
+        update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,22 +1,22 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "daily"
+      interval: 'daily'
     reviewers:
-      - "mobu-of-the-world/maintainers"
+      - 'mobu-of-the-world/maintainers'
     labels:
       - automerge
   - package-ecosystem: npm
-    directory: "/"
+    directory: '/'
     schedule:
       interval: daily
     open-pull-requests-limit: 10
     reviewers:
-      - "mobu-of-the-world/maintainers"
+      - 'mobu-of-the-world/maintainers'
     labels:
       - automerge
     ignore:
-      - dependency-name: "@types/*"
-        update-types: ["version-update:semver-major"]
+      - dependency-name: '@types/*'
+        update-types: ['version-update:semver-major']

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,12 +13,12 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ main ]
+    branches: [main]
   schedule:
-    - cron: '19 13 * * 6'
+    - cron: "19 13 * * 6"
 
 jobs:
   analyze:
@@ -28,40 +28,40 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript' ]
+        language: ["javascript"]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
         # Learn more:
         # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+          # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 https://git.io/JvXDl
 
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
+      # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+      #    and modify them (or add more) to build your code if your project
+      #    uses a compiled language
 
-    #- run: |
-    #   make bootstrap
-    #   make release
+      #- run: |
+      #   make bootstrap
+      #   make release
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,7 +9,7 @@
 # the `language` matrix defined below to confirm you have the correct set of
 # supported CodeQL languages.
 #
-name: "CodeQL"
+name: 'CodeQL'
 
 on:
   push:
@@ -18,7 +18,7 @@ on:
     # The branches below must be a subset of the branches above
     branches: [main]
   schedule:
-    - cron: "19 13 * * 6"
+    - cron: '19 13 * * 6'
 
 jobs:
   analyze:
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ["javascript"]
+        language: ['javascript']
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
         # Learn more:
         # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,10 +1,10 @@
-name: "Dependency Review"
+name: 'Dependency Review'
 on:
   pull_request:
     paths:
-      - ".github/workflows/**"
-      - "package.json"
-      - "package-lock.json"
+      - '.github/workflows/**'
+      - 'package.json'
+      - 'package-lock.json'
 
 permissions:
   contents: read
@@ -13,7 +13,7 @@ jobs:
   dependency-review:
     runs-on: ubuntu-latest
     steps:
-      - name: "Checkout Repository"
+      - name: 'Checkout Repository'
         uses: actions/checkout@v3
-      - name: "Dependency Review"
+      - name: 'Dependency Review'
         uses: actions/dependency-review-action@v2

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,10 +1,10 @@
-name: 'Dependency Review'
+name: "Dependency Review"
 on:
   pull_request:
     paths:
-      - '.github/workflows/**'
-      - 'package.json'
-      - 'package-lock.json'
+      - ".github/workflows/**"
+      - "package.json"
+      - "package-lock.json"
 
 permissions:
   contents: read
@@ -13,7 +13,7 @@ jobs:
   dependency-review:
     runs-on: ubuntu-latest
     steps:
-      - name: 'Checkout Repository'
+      - name: "Checkout Repository"
         uses: actions/checkout@v3
-      - name: 'Dependency Review'
+      - name: "Dependency Review"
         uses: actions/dependency-review-action@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,6 +95,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: dprint/check@v2.0
       - uses: actions/setup-node@v3
         with:
           node-version: 18
@@ -117,5 +118,4 @@ jobs:
         run: npm install
       - name: lint
         run: |
-          npm run prettier-check
           npm run eslint

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "dprint.dprint"
+  ]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
   "recommendations": [
+    "dbaeumer.vscode-eslint",
     "dprint.dprint"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
   "typescript.tsdk": "node_modules/typescript/lib",
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.defaultFormatter": "dprint.dprint",
   "editor.formatOnSave": true
 }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 # mobu
+
+<!-- dprint-ignore-start -->
+
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-7-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
+
+<!-- dprint-ignore-end -->
 
 [![Actions Status](https://github.com/mobu-of-the-world/mobu/workflows/CI/badge.svg)](https://github.com/mobu-of-the-world/mobu/actions)
 
@@ -37,10 +42,11 @@ MIT
 
 Yosuke Akatsuka (a.k.a [pankona](https://github.com/pankona))
 
-
 ## Contributors ✨
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+
+<!-- dprint-ignore-start -->
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->
@@ -59,7 +65,8 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
-
 <!-- ALL-CONTRIBUTORS-LIST:END -->
+
+<!-- dprint-ignore-end -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/dprint.json
+++ b/dprint.json
@@ -10,7 +10,7 @@
   },
   "markdown": {
   },
-  "includes": ["**/*.{ts,tsx,js,jsx,cjs,mjs,json,md,html,css}"],
+  "includes": ["**/*.{ts,tsx,js,jsx,cjs,mjs,json,md,html,css,yml}"],
   "excludes": [
     ".git",
     "**/node_modules",

--- a/dprint.json
+++ b/dprint.json
@@ -10,6 +10,9 @@
   },
   "markdown": {
   },
+  "prettier": {
+    "singleQuote": true
+  },
   "includes": ["**/*.{ts,tsx,js,jsx,cjs,mjs,json,md,html,css,yml}"],
   "excludes": [
     ".git",

--- a/dprint.json
+++ b/dprint.json
@@ -3,7 +3,8 @@
     "module.sortImportDeclarations": "maintain",
     "module.sortExportDeclarations": "maintain",
     "importDeclaration.sortNamedImports": "maintain",
-    "exportDeclaration.sortNamedExports": "maintain"
+    "exportDeclaration.sortNamedExports": "maintain",
+    "operatorPosition": "sameLine"
   },
   "json": {
   },

--- a/dprint.json
+++ b/dprint.json
@@ -1,0 +1,25 @@
+{
+  "typescript": {
+    "module.sortImportDeclarations": "maintain",
+    "module.sortExportDeclarations": "maintain",
+    "importDeclaration.sortNamedImports": "maintain",
+    "exportDeclaration.sortNamedExports": "maintain"
+  },
+  "json": {
+  },
+  "markdown": {
+  },
+  "includes": ["**/*.{ts,tsx,js,jsx,cjs,mjs,json,md,html,css}"],
+  "excludes": [
+    ".git",
+    "**/node_modules",
+    "**/*-lock.json",
+    "build"
+  ],
+  "plugins": [
+    "https://plugins.dprint.dev/typescript-0.69.5.wasm",
+    "https://plugins.dprint.dev/json-0.15.3.wasm",
+    "https://plugins.dprint.dev/markdown-0.13.3.wasm",
+    "https://plugins.dprint.dev/prettier-0.9.0.json@76c20538ea4231b3daa9b62059f90ec144200cab5477b7e95b730cbb3ed48957"
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@typescript-eslint/eslint-plugin": "^5.30.0",
         "@typescript-eslint/parser": "^5.30.0",
         "@vitejs/plugin-react": "^1.3.2",
+        "dprint": "^0.30.0",
         "esbuild": "^0.14.48",
         "eslint": "^8.18.0",
         "eslint-plugin-deprecation": "^1.3.2",
@@ -2405,6 +2406,15 @@
         "node-int64": "^0.4.0"
       }
     },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -2688,6 +2698,19 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.14.tgz",
       "integrity": "sha512-NMt+m9zFMPZe0JcY9gN224Qvk6qLIdqex29clBvc/y75ZBX9YA9wNK3frsYvu2DI1xcCIwxwnX+TlsJ2DSOADg==",
       "dev": true
+    },
+    "node_modules/dprint": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/dprint/-/dprint-0.30.0.tgz",
+      "integrity": "sha512-9HtWvFM02I66k5VU1iUWkpD0HJ9jvsFQALQzB8qat0N8YcSeyBPthIy8AqBnIE/ahVTaQXooPGV3WWoWXlRwFA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "yauzl": "=2.10.0"
+      },
+      "bin": {
+        "dprint": "bin.js"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.148",
@@ -3493,6 +3516,15 @@
       "dev": true,
       "dependencies": {
         "bser": "2.1.1"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "dependencies": {
+        "pend": "~1.2.0"
       }
     },
     "node_modules/file-entry-cache": {
@@ -5275,6 +5307,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true
+    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -6271,6 +6309,16 @@
       "dev": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/yn": {
@@ -8035,6 +8083,12 @@
         "node-int64": "^0.4.0"
       }
     },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true
+    },
     "buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -8254,6 +8308,15 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.14.tgz",
       "integrity": "sha512-NMt+m9zFMPZe0JcY9gN224Qvk6qLIdqex29clBvc/y75ZBX9YA9wNK3frsYvu2DI1xcCIwxwnX+TlsJ2DSOADg==",
       "dev": true
+    },
+    "dprint": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/dprint/-/dprint-0.30.0.tgz",
+      "integrity": "sha512-9HtWvFM02I66k5VU1iUWkpD0HJ9jvsFQALQzB8qat0N8YcSeyBPthIy8AqBnIE/ahVTaQXooPGV3WWoWXlRwFA==",
+      "dev": true,
+      "requires": {
+        "yauzl": "=2.10.0"
+      }
     },
     "electron-to-chromium": {
       "version": "1.4.148",
@@ -8767,6 +8830,15 @@
       "dev": true,
       "requires": {
         "bser": "2.1.1"
+      }
+    },
+    "fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "requires": {
+        "pend": "~1.2.0"
       }
     },
     "file-entry-cache": {
@@ -10118,6 +10190,12 @@
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true
     },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true
+    },
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -10792,6 +10870,16 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
       "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
       "dev": true
+    },
+    "yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
     },
     "yn": {
       "version": "3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "eslint-plugin-prefer-arrow": "^1.2.3",
         "eslint-plugin-react-hooks": "^4.6.0",
         "jest": "^28.1.2",
-        "prettier": "^2.7.1",
         "ts-jest": "^28.0.5",
         "ts-node": "^10.8.1",
         "typescript": "^4.7.4",
@@ -5348,21 +5347,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
-      "dev": true,
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
     "node_modules/pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -10176,12 +10160,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-      "dev": true
-    },
-    "prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
       "dev": true
     },
     "pretty-format": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@typescript-eslint/eslint-plugin": "^5.30.0",
     "@typescript-eslint/parser": "^5.30.0",
     "@vitejs/plugin-react": "^1.3.2",
+    "dprint": "^0.30.0",
     "esbuild": "^0.14.48",
     "eslint": "^8.18.0",
     "eslint-plugin-deprecation": "^1.3.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-react-hooks": "^4.6.0",
     "jest": "^28.1.2",
-    "prettier": "^2.7.1",
     "ts-jest": "^28.0.5",
     "ts-node": "^10.8.1",
     "typescript": "^4.7.4",

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "build": "tsc --noEmit && vite build",
     "test": "jest --watch",
     "test:ci": "jest",
-    "prettier-check": "prettier --list-different \"src/**/*.{ts,tsx,css,scss}\"",
-    "prettier:fix": "prettier --write \"src/**/*.{ts,tsx,css,scss}\"",
+    "format:check": "dprint check",
+    "format:fix": "dprint fmt",
     "eslint": "eslint \"src/**/*.{ts,tsx}\"",
     "eslint:fix": "eslint --fix \"src/**/*.{ts,tsx}\""
   },

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>kachick/renovate-config-dprint"
+  ],
+  "labels": ["dependencies", "renovate"],
+  "automerge": true,
+  "packageRules": [
+    {
+      "groupName": "node",
+      "matchPackageNames": ["node"],
+      "enabled": false
+    }
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -5,11 +5,5 @@
   ],
   "labels": ["dependencies", "renovate"],
   "automerge": true,
-  "packageRules": [
-    {
-      "groupName": "node",
-      "matchPackageNames": ["node"],
-      "enabled": false
-    }
-  ]
+  "enabledManagers": ["regex"]
 }

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,2 +1,1 @@
-export const GITHUB_REPOSITORY_URL =
-  "https://github.com/mobu-of-the-world/mobu" as const;
+export const GITHUB_REPOSITORY_URL = "https://github.com/mobu-of-the-world/mobu" as const;

--- a/src/common/cssHelpers.test.ts
+++ b/src/common/cssHelpers.test.ts
@@ -3,10 +3,10 @@ import { buildClassNames } from "./cssHelpers";
 
 test("returns combined classnames as a string that trimmed empty", async () => {
   expect(buildClassNames(["button", "button-primary"])).toBe(
-    "button button-primary"
+    "button button-primary",
   );
   expect(buildClassNames(["button", undefined])).toBe("button");
   expect(buildClassNames(["button", undefined, "hidden"])).toBe(
-    "button hidden"
+    "button hidden",
   );
 });

--- a/src/common/cssHelpers.ts
+++ b/src/common/cssHelpers.ts
@@ -1,2 +1,1 @@
-export const buildClassNames = (classNames: (string | undefined)[]): string =>
-  classNames.filter(Boolean).join(" ");
+export const buildClassNames = (classNames: (string | undefined)[]): string => classNames.filter(Boolean).join(" ");

--- a/src/common/usersContexts.tsx
+++ b/src/common/usersContexts.tsx
@@ -3,7 +3,7 @@ import { getStorageUsers, setStorageUsers } from "./storage";
 
 const usersContext = createContext<string[]>([]);
 const setPersistedUsersContext = createContext<(newUsers: string[]) => void>(
-  () => undefined
+  () => undefined,
 );
 
 export const UsersProvider = ({ children }: { children: ReactElement }) => {

--- a/src/header/Menu.tsx
+++ b/src/header/Menu.tsx
@@ -4,8 +4,7 @@ import { buildClassNames } from "../common/cssHelpers";
 
 import css from "./Menu.module.css";
 
-const visibilityClassname = (isVisible: boolean): "visible" | "hidden" =>
-  isVisible ? "visible" : "hidden";
+const visibilityClassname = (isVisible: boolean): "visible" | "hidden" => isVisible ? "visible" : "hidden";
 
 const Menu = ({
   isVisible,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,5 +11,5 @@ assertIsDefined<typeof root>(root);
 createRoot(root).render(
   <StrictMode>
     <App />
-  </StrictMode>
+  </StrictMode>,
 );

--- a/src/session/Interval.tsx
+++ b/src/session/Interval.tsx
@@ -27,7 +27,7 @@ const Interval = ({
           setIntervalSeconds(newIntervalSeconds);
         }
       },
-      [setIntervalSeconds]
+      [setIntervalSeconds],
     ),
     minutes: useCallback(
       (event: ChangeEvent<HTMLInputElement>) => {
@@ -37,7 +37,7 @@ const Interval = ({
           setIntervalSeconds(newIntervalSeconds);
         }
       },
-      [setIntervalSeconds]
+      [setIntervalSeconds],
     ),
   }[unit];
 

--- a/src/session/Session.tsx
+++ b/src/session/Session.tsx
@@ -3,10 +3,7 @@ import { useState } from "react";
 import Timer from "./Timer";
 import Interval from "./Interval";
 import SoundConfig from "./SoundConfig";
-import {
-  getStorageSoundEnabled,
-  setStorageSoundEnabled,
-} from "../common/storage";
+import { getStorageSoundEnabled, setStorageSoundEnabled } from "../common/storage";
 
 import css from "./Session.module.css";
 
@@ -15,10 +12,10 @@ const initialIntervalSeconds = 60 * 30;
 const Session = () => {
   const [iterationCount, setIterationCount] = useState(0);
   const [intervalSeconds, setIntervalSeconds] = useState(
-    initialIntervalSeconds
+    initialIntervalSeconds,
   );
   const [isSoundEnabled, setIsSoundEnabled] = useState(
-    getStorageSoundEnabled()
+    getStorageSoundEnabled(),
   );
 
   return (

--- a/src/session/SoundConfig.tsx
+++ b/src/session/SoundConfig.tsx
@@ -18,7 +18,7 @@ const SoundConfig = (props: SoundConfigProps) => {
   return (
     <div className={css["sound-config"]}>
       <span className={css["sound-config-label"]}>
-        <Text>Bell 🛎 : </Text>
+        <Text>{`Bell 🛎 : `}</Text>
       </span>
       <Checkbox {...inputProps} />
     </div>

--- a/src/session/Timer.tsx
+++ b/src/session/Timer.tsx
@@ -35,9 +35,9 @@ const Timer = ({
         setCountInIteration(0);
         setIsCounting(false);
         setPersistedUsers(
-          users.length >= 2
-            ? [...users.slice(1, users.length), users[0]].flatMap((user) => user ? [user] : [])
-            : users,
+          users.length >= 2 ?
+            [...users.slice(1, users.length), users[0]].flatMap((user) => user ? [user] : []) :
+            users,
         );
         if (isSoundEnabled) {
           const bell = new Audio(audiofile);

--- a/src/session/Timer.tsx
+++ b/src/session/Timer.tsx
@@ -36,10 +36,8 @@ const Timer = ({
         setIsCounting(false);
         setPersistedUsers(
           users.length >= 2
-            ? [...users.slice(1, users.length), users[0]].flatMap((user) =>
-                user ? [user] : []
-              )
-            : users
+            ? [...users.slice(1, users.length), users[0]].flatMap((user) => user ? [user] : [])
+            : users,
         );
         if (isSoundEnabled) {
           const bell = new Audio(audiofile);
@@ -53,7 +51,7 @@ const Timer = ({
         setCountTotal(countTotal + 1);
       }
     },
-    isCounting ? 1000 : null
+    isCounting ? 1000 : null,
   );
 
   const onStartOrPause = useCallback(() => {
@@ -66,9 +64,11 @@ const Timer = ({
       setIterationCount(1);
 
       if (window.Notification && Notification.permission !== "granted") {
-        const alertMessageByNotificationPermission: Readonly<{
-          [key in NotificationPermission]: string;
-        }> = {
+        const alertMessageByNotificationPermission: Readonly<
+          {
+            [key in NotificationPermission]: string;
+          }
+        > = {
           granted: "Thanks to accept the notification :)",
           denied: "You rejected the notification :(Please accept it.",
           default: "Can not judge to use notification :(Please accept it.",

--- a/src/session/Timer.tsx
+++ b/src/session/Timer.tsx
@@ -31,7 +31,7 @@ const Timer = ({
   useInterval(
     () => {
       if (countInIteration > 0 && countInIteration % intervalSeconds === 0) {
-        setIterationCount(countTotal / intervalSeconds + 1);
+        setIterationCount((countTotal / intervalSeconds) + 1);
         setCountInIteration(0);
         setIsCounting(false);
         setPersistedUsers(

--- a/src/userList/UserList.tsx
+++ b/src/userList/UserList.tsx
@@ -52,13 +52,12 @@ const UserList = () => {
               ev.preventDefault();
               const droppedData = ev.dataTransfer.getData("text/plain");
               const droppedMatchedGroups = droppedData.match(
-                /^user-(?<droppedUsername>.+)$/
+                /^user-(?<droppedUsername>.+)$/,
               )?.groups;
-              const droppedUsername =
-                droppedMatchedGroups && droppedMatchedGroups["droppedUsername"];
+              const droppedUsername = droppedMatchedGroups && droppedMatchedGroups["droppedUsername"];
               if (typeof droppedUsername === "string") {
                 setPersistedUsers(
-                  newUsersAfterDropped(users, user, droppedUsername)
+                  newUsersAfterDropped(users, user, droppedUsername),
                 );
               }
               return false;

--- a/src/userList/UserListHelpers.ts
+++ b/src/userList/UserListHelpers.ts
@@ -1,13 +1,13 @@
 export const newUsersAfterDropped = (
   originalUsers: string[],
   currentUser: string,
-  droppedUser: string
+  droppedUser: string,
 ): string[] => {
   const droppedUserNewIndex = originalUsers.findIndex(
-    (element) => element === currentUser
+    (element) => element === currentUser,
   );
   const droppedUserOldIndex = originalUsers.findIndex(
-    (element) => element === droppedUser
+    (element) => element === droppedUser,
   );
   const newUsers = [...originalUsers];
 

--- a/src/userList/UserRegister.tsx
+++ b/src/userList/UserRegister.tsx
@@ -28,9 +28,9 @@ const UserRegister = () => {
     },
     [setPersistedUsers, username, users],
   );
-  const registerDisabled = username === emptyUsername
-    || blankStringsPattern.test(username)
-    || users.includes(username);
+  const registerDisabled = username === emptyUsername ||
+    blankStringsPattern.test(username) ||
+    users.includes(username);
 
   return (
     <div className={css["userregister"]}>

--- a/src/userList/UserRegister.tsx
+++ b/src/userList/UserRegister.tsx
@@ -18,7 +18,7 @@ const UserRegister = () => {
     (event: React.ChangeEvent<HTMLInputElement>) => {
       setUsername(event.currentTarget.value);
     },
-    []
+    [],
   );
   const onUserRegister = useCallback(
     (event: React.FormEvent<HTMLFormElement>) => {
@@ -26,12 +26,11 @@ const UserRegister = () => {
       setPersistedUsers([...users, username.trim()]);
       setUsername(emptyUsername);
     },
-    [setPersistedUsers, username, users]
+    [setPersistedUsers, username, users],
   );
-  const registerDisabled =
-    username === emptyUsername ||
-    blankStringsPattern.test(username) ||
-    users.includes(username);
+  const registerDisabled = username === emptyUsername
+    || blankStringsPattern.test(username)
+    || users.includes(username);
 
   return (
     <div className={css["userregister"]}>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
       "esnext"
     ],
     "noEmit": true,
-    "jsx": "react-jsx",
+    "jsx": "react-jsx"
   },
   "include": ["src/**/*", "tests/**/*", "*.config.ts"]
 }


### PR DESCRIPTION
dprint vs prettier
---

Both have the strongness. Prettier has strong opinion and huge community, and looks stable behavior in these days.
dprint is pluggable, configurable and super fast ⚡.

Why dprint now?
---

Because prettier does not provide some options with their opinion.
A most negative to me is prettier/prettier#187.
I strongly agree eslint rule [no-mixed-operators](https://eslint.org/docs/latest/rules/no-mixed-operators).
At least, added parenthesis should not be removed by formatter if it was coder wanted.
However no option exists when using prettier.
It is a blocker to me especially developing around timer logics as #486.

Dprint is frequently developing now. So some style can't be adjusted to prettier does well.
But I 👍 for their decisions and I think it is enough ready to be used.

How
---

This PR does not perfectly drop prettier, it still used in HTML, CSS and YAML. Dprint runs on TypeScript, JavaScript, JSON, Markdown.
And needed to enable renovate to upgrade their plugins.

Configure
---

Some choice exists, however I have chosen minimum one.
If you strongly want enable some options, look at https://dprint.dev/config/ and https://dprint.dev/plugins/typescript/.
I can't reproduce 100% prettier behaviors even I have tried with some options in few hours.

Refs
---

🇯🇵 

* http://var.blog.jp/archives/86088118.html
* https://github.com/kachick/times_kachick/issues/164
* https://github.com/kachick/times_kachick/issues/168
* https://github.com/kachick/times_kachick/issues/171

