### PR TITLE
Clarify tsc is a prebuild requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   },
   "scripts": {
     "start": "vite",
-    "build": "tsc --noEmit && vite build",
+    "prebuild": "tsc",
+    "build": "vite build",
     "test": "jest --watch",
     "test:ci": "jest",
     "format:check": "dprint check",


### PR DESCRIPTION
* In npm scripts. `pre*` and `post*` runs before and after the runner. 
* noEmit is already clarified in tsconfig.json https://github.com/mobu-of-the-world/mobu/blob/f4f4019a71e19f5f04eb3e04f435253ef821b48e/tsconfig.json#L9

ref: https://docs.npmjs.com/cli/v8/using-npm/scripts