### PR TITLE
Disable to assign reviewers for dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,6 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
-    reviewers:
-      - 'mobu-of-the-world/maintainers'
     labels:
       - automerge
   - package-ecosystem: npm
@@ -13,8 +11,6 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 10
-    reviewers:
-      - 'mobu-of-the-world/maintainers'
     labels:
       - automerge
     ignore:


### PR DESCRIPTION
Since enabling automerge, I don't track them. If CI failed, we can know them easy. @pankona How do you think?