### PR TITLE
Skip needless CIs

### DIFF
--- a/.github/workflows/dprint.yml
+++ b/.github/workflows/dprint.yml
@@ -1,0 +1,19 @@
+name: dprint
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'package-lock.json'
+  pull_request:
+    paths-ignore:
+      - 'package-lock.json'
+
+jobs:
+  check:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dprint/check@v2.1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,21 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '.editorconfig'
+      - '**.md'
+      - '.vscode/**'
+      - 'dprint.json'
+      - 'renovate.json'
+      - '.eslintrc.json'
   pull_request:
+    paths-ignore:
+      - '.editorconfig'
+      - '**.md'
+      - '.vscode/**'
+      - 'dprint.json'
+      - 'renovate.json'
+      - '.eslintrc.json'
 
 jobs:
   typecheck:
@@ -51,10 +65,3 @@ jobs:
       - name: lint
         run: |
           npm run eslint
-
-  check-format:
-    timeout-minutes: 5
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: dprint/check@v2.1


### PR DESCRIPTION
Extracted dprint CI from main. It is fast, other main jobs needs npm install. It is annoy to take time even if changing documents,