### PR TITLE
Prefer dvh rather than vh for mobile view especially iOS

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,9 +1,9 @@
 html {
-  height: 100vh;
+  height: 100dvh;
 }
 
 body {
-  height: 100vh;
+  height: 100dvh;
 }
 
 #root {


### PR DESCRIPTION
This backports https://github.com/mobu-of-the-world/emobu/commit/ff837ded03fa9185df020f17012fedbd42ec5f52

Update #133 and #448

Currently mobile device hides the footer with the handling vh. So I have changed to use dvh to fix the issue. I have checked my Pixel 6a and iPad Pro.

I don't set any fallback styles because this tool should be used by edge devs 😬 

ref: 🗾 https://coliss.com/articles/build-websites/operation/css/large-small-dynamic-viewports.html, https://zenn.dev/futa/articles/90d7410650a73e, https://zenn.dev/moneyforward/articles/svh-dvh-lvh-for-all-browser