### PR TITLE
Replace ts-node with tsx

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,19 @@ See the section about [Test runner](https://nodejs.org/docs/latest-v18.x/api/tes
 Builds the app for production to the `build` folder.<br />
 It correctly bundles React in production mode and optimizes the build for the best performance.
 
+## How to run repl
+
+```ts
+❯ npx tsx
+> const n: string = 42; // You can write with TypeScript except actual type checking
+> const { shuffleArray } = await import('./src/common/listHelpers');
+undefined
+> shuffleArray([1, 2, 3, 4, 5]);
+[ 4, 2, 1, 3, 5 ]
+> shuffleArray([1, 2, 3, 4, 5]);
+[ 3, 2, 1, 4, 5 ]
+```
+
 ## How to update contributors list
 
 Members will update the list with this command after merging your PR.

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,8 +28,8 @@
         "eslint-plugin-deprecation": "^1.3.3",
         "eslint-plugin-prefer-arrow": "^1.2.3",
         "eslint-plugin-react-hooks": "^4.6.0",
-        "ts-node": "^10.9.1",
         "ts-node-test": "^0.3.0",
+        "tsx": "^3.12.3",
         "typescript": "^4.9.5",
         "vite": "^4.1.1"
       }
@@ -525,6 +525,36 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@esbuild-kit/cjs-loader": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/cjs-loader/-/cjs-loader-2.4.2.tgz",
+      "integrity": "sha512-BDXFbYOJzT/NBEtp71cvsrGPwGAMGRB/349rwKuoxNSiKjPraNNnlK6MIIabViCjqZugu6j+xeMDlEkWdHHJSg==",
+      "dev": true,
+      "dependencies": {
+        "@esbuild-kit/core-utils": "^3.0.0",
+        "get-tsconfig": "^4.4.0"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/core-utils/-/core-utils-3.1.0.tgz",
+      "integrity": "sha512-Uuk8RpCg/7fdHSceR1M6XbSZFSuMrxcePFuGgyvsBn+u339dk5OeL4jv2EojwTN2st/unJGsVm4qHWjWNmJ/tw==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "~0.17.6",
+        "source-map-support": "^0.5.21"
+      }
+    },
+    "node_modules/@esbuild-kit/esm-loader": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/esm-loader/-/esm-loader-2.5.5.tgz",
+      "integrity": "sha512-Qwfvj/qoPbClxCRNuac1Du01r9gvNOT+pMYtJDapfB1eoGN1YlJ1BixLyL9WVENRx5RXgNLdfYdx/CuswlGhMw==",
+      "dev": true,
+      "dependencies": {
+        "@esbuild-kit/core-utils": "^3.0.0",
+        "get-tsconfig": "^4.4.0"
       }
     },
     "node_modules/@esbuild/android-arm": {
@@ -1857,6 +1887,12 @@
         "node": "*"
       }
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
+    },
     "node_modules/call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -2640,6 +2676,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.4.0.tgz",
+      "integrity": "sha512-0Gdjo/9+FzsYhXCEFueo2aY1z1tpXrxWZzP7k8ul9qt1U5o8rYJwTJYmaeHdrVosYIVYkOy2iwCJ9FdpocJhPQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/glob": {
@@ -3851,6 +3896,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
@@ -3858,6 +3912,16 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/string-width": {
@@ -4037,6 +4101,23 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
+    },
+    "node_modules/tsx": {
+      "version": "3.12.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-3.12.3.tgz",
+      "integrity": "sha512-Wc5BFH1xccYTXaQob+lEcimkcb/Pq+0en2s+ruiX0VEIC80nV7/0s7XRahx8NnsoCnpCVUPz8wrqVSPi760LkA==",
+      "dev": true,
+      "dependencies": {
+        "@esbuild-kit/cjs-loader": "^2.4.2",
+        "@esbuild-kit/core-utils": "^3.0.0",
+        "@esbuild-kit/esm-loader": "^2.5.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.js"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -5109,6 +5190,36 @@
         }
       }
     },
+    "@esbuild-kit/cjs-loader": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/cjs-loader/-/cjs-loader-2.4.2.tgz",
+      "integrity": "sha512-BDXFbYOJzT/NBEtp71cvsrGPwGAMGRB/349rwKuoxNSiKjPraNNnlK6MIIabViCjqZugu6j+xeMDlEkWdHHJSg==",
+      "dev": true,
+      "requires": {
+        "@esbuild-kit/core-utils": "^3.0.0",
+        "get-tsconfig": "^4.4.0"
+      }
+    },
+    "@esbuild-kit/core-utils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/core-utils/-/core-utils-3.1.0.tgz",
+      "integrity": "sha512-Uuk8RpCg/7fdHSceR1M6XbSZFSuMrxcePFuGgyvsBn+u339dk5OeL4jv2EojwTN2st/unJGsVm4qHWjWNmJ/tw==",
+      "dev": true,
+      "requires": {
+        "esbuild": "~0.17.6",
+        "source-map-support": "^0.5.21"
+      }
+    },
+    "@esbuild-kit/esm-loader": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/esm-loader/-/esm-loader-2.5.5.tgz",
+      "integrity": "sha512-Qwfvj/qoPbClxCRNuac1Du01r9gvNOT+pMYtJDapfB1eoGN1YlJ1BixLyL9WVENRx5RXgNLdfYdx/CuswlGhMw==",
+      "dev": true,
+      "requires": {
+        "@esbuild-kit/core-utils": "^3.0.0",
+        "get-tsconfig": "^4.4.0"
+      }
+    },
     "@esbuild/android-arm": {
       "version": "0.17.7",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.7.tgz",
@@ -5911,6 +6022,12 @@
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
       "dev": true
     },
+    "buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
+    },
     "call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -6511,6 +6628,12 @@
         "has": "^1.0.3",
         "has-symbols": "^1.0.3"
       }
+    },
+    "get-tsconfig": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.4.0.tgz",
+      "integrity": "sha512-0Gdjo/9+FzsYhXCEFueo2aY1z1tpXrxWZzP7k8ul9qt1U5o8rYJwTJYmaeHdrVosYIVYkOy2iwCJ9FdpocJhPQ==",
+      "dev": true
     },
     "glob": {
       "version": "7.2.3",
@@ -7343,11 +7466,27 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
     },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
     "source-map-js": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
       "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
     },
     "string-width": {
       "version": "4.2.3",
@@ -7463,6 +7602,18 @@
           "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
           "dev": true
         }
+      }
+    },
+    "tsx": {
+      "version": "3.12.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-3.12.3.tgz",
+      "integrity": "sha512-Wc5BFH1xccYTXaQob+lEcimkcb/Pq+0en2s+ruiX0VEIC80nV7/0s7XRahx8NnsoCnpCVUPz8wrqVSPi760LkA==",
+      "dev": true,
+      "requires": {
+        "@esbuild-kit/cjs-loader": "^2.4.2",
+        "@esbuild-kit/core-utils": "^3.0.0",
+        "@esbuild-kit/esm-loader": "^2.5.5",
+        "fsevents": "~2.3.2"
       }
     },
     "type-check": {

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "eslint-plugin-deprecation": "^1.3.3",
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "ts-node": "^10.9.1",
     "ts-node-test": "^0.3.0",
+    "tsx": "^3.12.3",
     "typescript": "^4.9.5",
     "vite": "^4.1.1"
   },


### PR DESCRIPTION
tsx is based on esbuild

I think we can drop ts-node since dropped jest in #725