### PR TITLE
Replace dprint prettier plugin with WASM plugins

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "dependencyDashboard": true,
   "extends": [
-    "config:js-app"
+    "config:js-app",
+    "github>kachick/renovate-config-dprint#1.1.0"
   ],
   "labels": ["dependencies", "renovate"],
   "automerge": true,

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <!-- dprint-ignore-start -->
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-<!-- prettier-ignore-start -->
 <!-- markdownlint-disable -->
 <table>
   <tbody>
@@ -50,7 +49,6 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 </table>
 
 <!-- markdownlint-restore -->
-<!-- prettier-ignore-end -->
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 

--- a/dprint.json
+++ b/dprint.json
@@ -24,6 +24,7 @@
     "https://plugins.dprint.dev/json-0.19.2.wasm",
     "https://plugins.dprint.dev/markdown-0.16.4.wasm",
     "https://plugins.dprint.dev/prettier-0.39.0.json@896b70f29ef8213c1b0ba81a93cee9c2d4f39ac2194040313cd433906db7bc7c",
-    "https://plugins.dprint.dev/g-plane/malva-v0.5.1.wasm"
+    "https://plugins.dprint.dev/g-plane/malva-v0.5.1.wasm",
+    "https://plugins.dprint.dev/g-plane/markup_fmt-v0.10.0.wasm"
   ]
 }

--- a/dprint.json
+++ b/dprint.json
@@ -10,6 +10,16 @@
   },
   "markdown": {
   },
+  "malva": {
+    "quotes": "preferSingle"
+  },
+  "markup": {
+    "styleIndent": true,
+    "doctypeKeywordCase": "ignore"
+  },
+  "yaml": {
+    "quotes": "preferSingle"
+  },
   "excludes": [
     ".git",
     "**/node_modules",

--- a/dprint.json
+++ b/dprint.json
@@ -10,9 +10,6 @@
   },
   "markdown": {
   },
-  "prettier": {
-    "singleQuote": true
-  },
   "excludes": [
     ".git",
     "**/node_modules",
@@ -23,7 +20,6 @@
     "https://plugins.dprint.dev/typescript-0.89.3.wasm",
     "https://plugins.dprint.dev/json-0.19.2.wasm",
     "https://plugins.dprint.dev/markdown-0.16.4.wasm",
-    "https://plugins.dprint.dev/prettier-0.39.0.json@896b70f29ef8213c1b0ba81a93cee9c2d4f39ac2194040313cd433906db7bc7c",
     "https://plugins.dprint.dev/g-plane/malva-v0.5.1.wasm",
     "https://plugins.dprint.dev/g-plane/markup_fmt-v0.10.0.wasm",
     "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.2.0.wasm"

--- a/dprint.json
+++ b/dprint.json
@@ -25,6 +25,7 @@
     "https://plugins.dprint.dev/markdown-0.16.4.wasm",
     "https://plugins.dprint.dev/prettier-0.39.0.json@896b70f29ef8213c1b0ba81a93cee9c2d4f39ac2194040313cd433906db7bc7c",
     "https://plugins.dprint.dev/g-plane/malva-v0.5.1.wasm",
-    "https://plugins.dprint.dev/g-plane/markup_fmt-v0.10.0.wasm"
+    "https://plugins.dprint.dev/g-plane/markup_fmt-v0.10.0.wasm",
+    "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.2.0.wasm"
   ]
 }

--- a/dprint.json
+++ b/dprint.json
@@ -23,6 +23,7 @@
     "https://plugins.dprint.dev/typescript-0.89.3.wasm",
     "https://plugins.dprint.dev/json-0.19.2.wasm",
     "https://plugins.dprint.dev/markdown-0.16.4.wasm",
-    "https://plugins.dprint.dev/prettier-0.39.0.json@896b70f29ef8213c1b0ba81a93cee9c2d4f39ac2194040313cd433906db7bc7c"
+    "https://plugins.dprint.dev/prettier-0.39.0.json@896b70f29ef8213c1b0ba81a93cee9c2d4f39ac2194040313cd433906db7bc7c",
+    "https://plugins.dprint.dev/g-plane/malva-v0.5.1.wasm"
   ]
 }

--- a/public/404.html
+++ b/public/404.html
@@ -53,11 +53,8 @@
         padding: 16px;
         border-radius: 4px;
       }
-      #message,
-      #message a {
-        box-shadow:
-          0 1px 3px rgba(0, 0, 0, 0.12),
-          0 1px 2px rgba(0, 0, 0, 0.24);
+      #message, #message a {
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
       }
       #load {
         color: rgba(0, 0, 0, 0.4);
@@ -65,8 +62,7 @@
         font-size: 13px;
       }
       @media (max-width: 600px) {
-        body,
-        #message {
+        body, #message {
           margin-top: 0;
           background: white;
           box-shadow: none;

--- a/src/session/Interval.module.css
+++ b/src/session/Interval.module.css
@@ -1,6 +1,5 @@
 @media screen and (max-width: 799px) {
-  .interval {
-  }
+  .interval {}
 }
 @media screen and (min-width: 800px) {
   .interval {


### PR DESCRIPTION
- **`npx dprint config add g-plane/malva`**
- **`npx dprint config add g-plane/markup_fmt`**
- **`npx dprint config add g-plane/pretty_yaml`**
- **Uninstall prettier plugin**
- **Add some settings to keep current behavior as possible**
- **`npx dprint fmt`**
- **Drop needless annotation since dropped prettier**
- **Add renovatebot config for updating dprint WASM plugins**

Make better integrations since https://github.com/mobu-of-the-world/mobu/pull/489